### PR TITLE
YouTube fix so that the result is always a video

### DIFF
--- a/youtube_plugin.js
+++ b/youtube_plugin.js
@@ -9,6 +9,7 @@ function YoutubePlugin () {
 	this.RickrollUrl = 'http://www.youtube.com/watch?v=oHg5SJYRHA0';
 	this.youtube = new youtube_node();
 	this.youtube.setKey(AuthDetails.youtube_api_key);
+	this.youtube.addParam('type', 'video');
 };
 
 


### PR DESCRIPTION
 If the first result returned is a channel, you'll get "undefined" as the video ID, leading to the URL "http://www.youtube.com/watch?v=undefined" to be constructed. Fixed this by adding the "type" parameter of "video" to the youtube plugin object. I was running across the error originally with the query "m2k".
